### PR TITLE
chore: Improve environment file configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,13 @@ dist-ssr
 *.sln
 *.sw?
 
+# Environment variables with secrets (DO NOT COMMIT)
+.env*.local
+.env.prod.local
+
 # User Data
 accounting_2-year.csv
 *.csv
+
+# Deployment data
+data/


### PR DESCRIPTION
## Summary

Update .gitignore to properly handle local environment configuration files while maintaining templates in version control.

## Changes

- Add `.env*.local` and `.env.prod.local` to ignored files for local deployment overrides
- Add `data/` directory to ignored files (deployment metadata, Prometheus/Grafana volumes)
- Keep `.env.prod` as template in git for Turnstile site key configuration
- Local deployment values (image digest, commit SHA, domain-specific settings) stay in `.env.prod.local`

## Benefits

- Developers can customize `.env.prod.local` for their environment without affecting git
- `.env.prod` stays as template for CI/CD and new deployments
- Deployment metadata doesn't pollute version control

## Testing

- [ ] Verify `.env.prod` is tracked (template)
- [ ] Verify `.env.prod.local` is ignored (local overrides)
- [ ] Verify `data/` directory is ignored